### PR TITLE
Prepare library for wrapping arbitrary ndarray like objects as ImgLib2 cached cell images

### DIFF
--- a/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
@@ -1,0 +1,633 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.basictypeaccess;
+
+import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.img.basictypeaccess.CharAccess;
+import net.imglib2.img.basictypeaccess.DoubleAccess;
+import net.imglib2.img.basictypeaccess.FloatAccess;
+import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.img.basictypeaccess.LongAccess;
+import net.imglib2.img.basictypeaccess.ShortAccess;
+import net.imglib2.img.basictypeaccess.array.AbstractByteArray;
+import net.imglib2.img.basictypeaccess.array.AbstractCharArray;
+import net.imglib2.img.basictypeaccess.array.AbstractDoubleArray;
+import net.imglib2.img.basictypeaccess.array.AbstractFloatArray;
+import net.imglib2.img.basictypeaccess.array.AbstractIntArray;
+import net.imglib2.img.basictypeaccess.array.AbstractLongArray;
+import net.imglib2.img.basictypeaccess.array.AbstractShortArray;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.CharArray;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileByteArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileCharArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileDoubleArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileFloatArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileIntArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileLongArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileShortArray;
+import net.imglib2.img.basictypelongaccess.unsafe.ByteUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.CharUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.DoubleUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.FloatUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.IntUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.LongUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.ShortUnsafe;
+import net.imglib2.type.PrimitiveType;
+
+/**
+ * Utility and helper methods for accesses ({@link ByteAccess} etc).
+ *
+ * @author Philipp Hanslovsky
+ */
+public interface Accesses
+{
+
+	public static ArrayDataAccess< ? > asArrayAccess(
+			final long address,
+			final int size,
+			final boolean volatil,
+			final PrimitiveType type )
+	{
+		switch ( type )
+		{
+		case BYTE:
+			return asByteArray( address, size, volatil );
+		case CHAR:
+			return asCharArray( address, size, volatil );
+		case SHORT:
+			return asShortArray( address, size, volatil );
+		case INT:
+			return asIntArray( address, size, volatil );
+		case LONG:
+			return asLongArray( address, size, volatil );
+		case FLOAT:
+			return asFloatArray( address, size, volatil );
+		case DOUBLE:
+			return asDoubleArray( address, size, volatil );
+		case UNDEFINED:
+		case BOOLEAN:
+		default:
+			throw new IllegalArgumentException( "Converting access for primtive type not supported: " + type );
+		}
+	}
+
+	public static AbstractByteArray< ? > asByteArray(
+			final long address,
+			final int size,
+			final boolean volatil )
+	{
+		final AbstractByteArray< ? > access = volatil ? new VolatileByteArray( size, true ) : new ByteArray( size );
+		copyAny( new ByteUnsafe( address ), 0, access, 0, size );
+		return access;
+	}
+
+	public static AbstractCharArray< ? > asCharArray(
+			final long address,
+			final int size,
+			final boolean volatil )
+	{
+		final AbstractCharArray< ? > access = volatil ? new VolatileCharArray( size, true ) : new CharArray( size );
+		copyAny( new CharUnsafe( address ), 0, access, 0, size );
+		return access;
+	}
+
+	public static AbstractShortArray< ? > asShortArray(
+			final long address,
+			final int size,
+			final boolean volatil )
+	{
+		final AbstractShortArray< ? > access = volatil ? new VolatileShortArray( size, true ) : new ShortArray( size );
+		copyAny( new ShortUnsafe( address ), 0, access, 0, size );
+		return access;
+	}
+
+	public static AbstractIntArray< ? > asIntArray(
+			final long address,
+			final int size,
+			final boolean volatil )
+	{
+		final AbstractIntArray< ? > access = volatil ? new VolatileIntArray( size, true ) : new IntArray( size );
+		copyAny( new IntUnsafe( address ), 0, access, 0, size );
+		return access;
+	}
+
+	public static AbstractLongArray< ? > asLongArray(
+			final long address,
+			final int size,
+			final boolean volatil )
+	{
+		final AbstractLongArray< ? > access = volatil ? new VolatileLongArray( size, true ) : new LongArray( size );
+		copyAny( new LongUnsafe( address ), 0, access, 0, size );
+		return access;
+	}
+
+	public static AbstractFloatArray< ? > asFloatArray(
+			final long address,
+			final int size,
+			final boolean volatil )
+	{
+		final AbstractFloatArray< ? > access = volatil ? new VolatileFloatArray( size, true ) : new FloatArray( size );
+		copyAny( new FloatUnsafe( address ), 0, access, 0, size );
+		return access;
+	}
+
+	public static AbstractDoubleArray< ? > asDoubleArray(
+			final long address,
+			final int size,
+			final boolean volatil )
+	{
+		final AbstractDoubleArray< ? > access = volatil ? new VolatileDoubleArray( size, true ) : new DoubleArray( size );
+		copyAny( new DoubleUnsafe( address ), 0, access, 0, size );
+		return access;
+	}
+
+	public static void copyAny(
+			final Object src,
+			final int srcPos,
+			final Object dest,
+			final int destPos,
+			final int length ) throws IllegalArgumentException
+	{
+		if ( src instanceof ByteAccess && dest instanceof ByteAccess )
+		{
+			copy( ( ByteAccess ) src, srcPos, ( ByteAccess ) dest, destPos, length );
+		}
+		else if ( src instanceof CharAccess && dest instanceof CharAccess )
+		{
+			copy( ( CharAccess ) src, srcPos, ( CharAccess ) dest, destPos, length );
+		}
+		else if ( src instanceof DoubleAccess && dest instanceof DoubleAccess )
+		{
+			copy( ( DoubleAccess ) src, srcPos, ( DoubleAccess ) dest, destPos, length );
+		}
+		else if ( src instanceof FloatAccess && dest instanceof FloatAccess )
+		{
+			copy( ( FloatAccess ) src, srcPos, ( FloatAccess ) dest, destPos, length );
+		}
+		else if ( src instanceof IntAccess && dest instanceof IntAccess )
+		{
+			copy( ( IntAccess ) src, srcPos, ( IntAccess ) dest, destPos, length );
+		}
+		else if ( src instanceof LongAccess && dest instanceof LongAccess )
+		{
+			copy( ( LongAccess ) src, srcPos, ( LongAccess ) dest, destPos, length );
+		}
+		else if ( src instanceof ShortAccess && dest instanceof ShortAccess )
+		{
+			copy( ( ShortAccess ) src, srcPos, ( ShortAccess ) dest, destPos, length );
+		}
+		else
+		{
+			throw new IllegalArgumentException( String.format(
+					"Expected src and dest to be same access type but got %s (src) and %s (dest).",
+					src == null ? src : src.getClass().getName(),
+					dest == null ? dest : dest.getClass().getName() ) );
+		}
+
+	}
+
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final ByteAccess src,
+			final int srcPos,
+			final ByteAccess dest,
+			final int destPos,
+			final int length )
+	{
+
+		if ( src == dest )
+		{
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+		}
+	}
+
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final CharAccess src,
+			final int srcPos,
+			final CharAccess dest,
+			final int destPos,
+			final int length )
+	{
+
+		if ( src == dest )
+		{
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+		}
+	}
+
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final DoubleAccess src,
+			final int srcPos,
+			final DoubleAccess dest,
+			final int destPos,
+			final int length )
+	{
+
+		if ( src == dest )
+		{
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+		}
+	}
+
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final FloatAccess src,
+			final int srcPos,
+			final FloatAccess dest,
+			final int destPos,
+			final int length )
+	{
+
+		if ( src == dest )
+		{
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+		}
+	}
+
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final IntAccess src,
+			final int srcPos,
+			final IntAccess dest,
+			final int destPos,
+			final int length )
+	{
+
+		if ( src == dest )
+		{
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+		}
+	}
+
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final LongAccess src,
+			final int srcPos,
+			final LongAccess dest,
+			final int destPos,
+			final int length )
+	{
+
+		if ( src == dest )
+		{
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+		}
+	}
+
+	/**
+	 *
+	 * Following {@link System#arraycopy}, copies {@code length} elements from
+	 * the specified source access, beginning at the specified position
+	 * {@code srcPos}, to the specified position of the destination array
+	 * {@code destPos}. A subsequence of access components are copied from the
+	 * source access referenced by {@code src} to the destination access
+	 * referenced by {@code dest}. The number of components copied is equal to
+	 * the {@code length} argument. The components at positions {@code srcPos}
+	 * through {@code srcPos+length-1} in the source array are copied into
+	 * positions {@code destPos} through {@code destPos+length-1}, respectively,
+	 * of the destination array.
+	 *
+	 * If the {@code src} and {@code dest} arguments refer to the same array
+	 * object, then the copying is performed as if the components at positions
+	 * {@code srcPos} through {@code srcPos+length-1} were first copied to a
+	 * temporary array with {@code length} components and then the contents of
+	 * the temporary array were copied into positions destPos through
+	 * {@code destPos+length-1} of the destination array.
+	 *
+	 * @param src
+	 *            the source access.
+	 * @param srcPos
+	 *            starting position in the source access.
+	 * @param dest
+	 *            the destination access.
+	 * @param destPos
+	 *            starting position in the destination access.
+	 * @param length
+	 *            the number of access elements to be copied
+	 */
+	public static void copy(
+			final ShortAccess src,
+			final int srcPos,
+			final ShortAccess dest,
+			final int destPos,
+			final int length )
+	{
+
+		if ( src == dest )
+		{
+			if ( srcPos == destPos ) { return; }
+			if ( srcPos < destPos )
+			{
+				for ( int index = length - 1; index >= 0; --index )
+				{
+					dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+				}
+			}
+			return;
+		}
+
+		for ( int index = 0; index < length; ++index )
+		{
+			dest.setValue( index + destPos, src.getValue( index + srcPos ) );
+		}
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/AbstractStridedUnsafeLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/AbstractStridedUnsafeLongAccess.java
@@ -1,18 +1,31 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
-public class AbstractStridedUnsafeLongAccess
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+
+public class AbstractStridedUnsafeLongAccess implements VolatileAccess
 {
+	protected static final boolean DEFAULT_IS_VALID = true;
+
 	protected final int stride;
 
-	public AbstractStridedUnsafeLongAccess( final int stride )
+	private final boolean isValid;
+
+	public AbstractStridedUnsafeLongAccess( final int stride, final boolean isValid )
 	{
 		super();
 		this.stride = stride;
+		this.isValid = isValid;
 	}
 
 	protected long getPosition( final long offset, final long index )
 	{
 		return offset + index * stride;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return isValid;
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ByteUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ByteUnsafe.java
@@ -1,9 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileByteAccess;
 import net.imglib2.img.basictypelongaccess.ByteLongAccess;
 
-public class ByteUnsafe implements ByteLongAccess, VolatileAccess
+public class ByteUnsafe implements ByteLongAccess, VolatileByteAccess
 {
 	private static final boolean DEFAULT_IS_VALID = true;
 

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ByteUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ByteUnsafe.java
@@ -71,4 +71,18 @@ public class ByteUnsafe implements ByteLongAccess, VolatileByteAccess
 		return this.isValid;
 	}
 
+	@Override
+	public void finalize() throws Throwable
+	{
+		try
+		{
+			if ( this.ownerReference instanceof Runnable )
+				( ( Runnable ) ownerReference ).run();
+		}
+		finally
+		{
+			super.finalize();
+		}
+	}
+
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ByteUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ByteUnsafe.java
@@ -1,24 +1,39 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.ByteLongAccess;
 
-public class ByteUnsafe implements ByteLongAccess
+public class ByteUnsafe implements ByteLongAccess, VolatileAccess
 {
+	private static final boolean DEFAULT_IS_VALID = true;
 
 	private final long address;
 
 	private final Object ownerReference;
+
+	private final boolean isValid;
 
 	public ByteUnsafe( final long address )
 	{
 		this( address, null );
 	}
 
+	public ByteUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
 	public ByteUnsafe( final long address, final Object ownerReference )
+	{
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	public ByteUnsafe( final long address, final Object ownerReference, final boolean isValid )
 	{
 		super();
 		this.address = address;
 		this.ownerReference = ownerReference;
+		this.isValid = true;
 	}
 
 	@Override
@@ -48,6 +63,12 @@ public class ByteUnsafe implements ByteLongAccess
 	public long getAddres()
 	{
 		return address;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return this.isValid;
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/CharUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/CharUnsafe.java
@@ -61,4 +61,18 @@ public class CharUnsafe extends AbstractStridedUnsafeLongAccess implements CharL
 		return address;
 	}
 
+	@Override
+	public void finalize() throws Throwable
+	{
+		try
+		{
+			if ( this.ownerReference instanceof Runnable )
+				( ( Runnable ) ownerReference ).run();
+		}
+		finally
+		{
+			super.finalize();
+		}
+	}
+
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/CharUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/CharUnsafe.java
@@ -1,8 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.CharLongAccess;
 
-public class CharUnsafe extends AbstractStridedUnsafeLongAccess implements CharLongAccess
+public class CharUnsafe extends AbstractStridedUnsafeLongAccess implements CharLongAccess, VolatileAccess
 {
 
 	private final long address;
@@ -14,9 +15,19 @@ public class CharUnsafe extends AbstractStridedUnsafeLongAccess implements CharL
 		this( address, null );
 	}
 
+	public CharUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
 	public CharUnsafe( final long address, final Object ownerReference )
 	{
-		super( Character.BYTES );
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	public CharUnsafe( final long address, final Object ownerReference, final boolean isValid )
+	{
+		super( Character.BYTES, isValid );
 		this.address = address;
 		this.ownerReference = ownerReference;
 	}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/CharUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/CharUnsafe.java
@@ -1,9 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileCharAccess;
 import net.imglib2.img.basictypelongaccess.CharLongAccess;
 
-public class CharUnsafe extends AbstractStridedUnsafeLongAccess implements CharLongAccess, VolatileAccess
+public class CharUnsafe extends AbstractStridedUnsafeLongAccess implements CharLongAccess, VolatileCharAccess
 {
 
 	private final long address;

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/DoubleUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/DoubleUnsafe.java
@@ -61,4 +61,18 @@ public class DoubleUnsafe extends AbstractStridedUnsafeLongAccess implements Dou
 		return address;
 	}
 
+	@Override
+	public void finalize() throws Throwable
+	{
+		try
+		{
+			if ( this.ownerReference instanceof Runnable )
+				( ( Runnable ) ownerReference ).run();
+		}
+		finally
+		{
+			super.finalize();
+		}
+	}
+
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/DoubleUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/DoubleUnsafe.java
@@ -1,8 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.DoubleLongAccess;
 
-public class DoubleUnsafe extends AbstractStridedUnsafeLongAccess implements DoubleLongAccess
+public class DoubleUnsafe extends AbstractStridedUnsafeLongAccess implements DoubleLongAccess, VolatileAccess
 {
 
 	private final long address;
@@ -14,9 +15,19 @@ public class DoubleUnsafe extends AbstractStridedUnsafeLongAccess implements Dou
 		this( address, null );
 	}
 
+	public DoubleUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
 	public DoubleUnsafe( final long address, final Object ownerReference )
 	{
-		super( Double.BYTES );
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	public DoubleUnsafe( final long address, final Object ownerReference, final boolean isValid )
+	{
+		super( Double.BYTES, isValid );
 		this.address = address;
 		this.ownerReference = ownerReference;
 	}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/DoubleUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/DoubleUnsafe.java
@@ -1,9 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileDoubleAccess;
 import net.imglib2.img.basictypelongaccess.DoubleLongAccess;
 
-public class DoubleUnsafe extends AbstractStridedUnsafeLongAccess implements DoubleLongAccess, VolatileAccess
+public class DoubleUnsafe extends AbstractStridedUnsafeLongAccess implements DoubleLongAccess, VolatileDoubleAccess
 {
 
 	private final long address;

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/FloatUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/FloatUnsafe.java
@@ -61,4 +61,18 @@ public class FloatUnsafe extends AbstractStridedUnsafeLongAccess implements Floa
 		return address;
 	}
 
+	@Override
+	public void finalize() throws Throwable
+	{
+		try
+		{
+			if ( this.ownerReference instanceof Runnable )
+				( ( Runnable ) ownerReference ).run();
+		}
+		finally
+		{
+			super.finalize();
+		}
+	}
+
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/FloatUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/FloatUnsafe.java
@@ -1,9 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileFloatAccess;
 import net.imglib2.img.basictypelongaccess.FloatLongAccess;
 
-public class FloatUnsafe extends AbstractStridedUnsafeLongAccess implements FloatLongAccess, VolatileAccess
+public class FloatUnsafe extends AbstractStridedUnsafeLongAccess implements FloatLongAccess, VolatileFloatAccess
 {
 
 	private final long address;

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/FloatUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/FloatUnsafe.java
@@ -1,8 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.FloatLongAccess;
 
-public class FloatUnsafe extends AbstractStridedUnsafeLongAccess implements FloatLongAccess
+public class FloatUnsafe extends AbstractStridedUnsafeLongAccess implements FloatLongAccess, VolatileAccess
 {
 
 	private final long address;
@@ -14,9 +15,19 @@ public class FloatUnsafe extends AbstractStridedUnsafeLongAccess implements Floa
 		this( address, null );
 	}
 
+	public FloatUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
 	public FloatUnsafe( final long address, final Object ownerReference )
 	{
-		super( Float.BYTES );
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	public FloatUnsafe( final long address, final Object ownerReference, final boolean isValid )
+	{
+		super( Float.BYTES, isValid );
 		this.address = address;
 		this.ownerReference = ownerReference;
 	}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/IntUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/IntUnsafe.java
@@ -61,4 +61,18 @@ public class IntUnsafe extends AbstractStridedUnsafeLongAccess implements IntLon
 		return address;
 	}
 
+	@Override
+	public void finalize() throws Throwable
+	{
+		try
+		{
+			if ( this.ownerReference instanceof Runnable )
+				( ( Runnable ) ownerReference ).run();
+		}
+		finally
+		{
+			super.finalize();
+		}
+	}
+
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/IntUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/IntUnsafe.java
@@ -1,9 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileIntAccess;
 import net.imglib2.img.basictypelongaccess.IntLongAccess;
 
-public class IntUnsafe extends AbstractStridedUnsafeLongAccess implements IntLongAccess, VolatileAccess
+public class IntUnsafe extends AbstractStridedUnsafeLongAccess implements IntLongAccess, VolatileIntAccess
 {
 
 	private final long address;

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/IntUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/IntUnsafe.java
@@ -1,8 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.IntLongAccess;
 
-public class IntUnsafe extends AbstractStridedUnsafeLongAccess implements IntLongAccess
+public class IntUnsafe extends AbstractStridedUnsafeLongAccess implements IntLongAccess, VolatileAccess
 {
 
 	private final long address;
@@ -14,9 +15,19 @@ public class IntUnsafe extends AbstractStridedUnsafeLongAccess implements IntLon
 		this( address, null );
 	}
 
+	public IntUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
 	public IntUnsafe( final long address, final Object ownerReference )
 	{
-		super( Integer.BYTES );
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	public IntUnsafe( final long address, final Object ownerReference, final boolean isValid )
+	{
+		super( Integer.BYTES, isValid );
 		this.address = address;
 		this.ownerReference = ownerReference;
 	}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/LongUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/LongUnsafe.java
@@ -1,9 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileLongAccess;
 import net.imglib2.img.basictypelongaccess.LongLongAccess;
 
-public class LongUnsafe extends AbstractStridedUnsafeLongAccess implements LongLongAccess, VolatileAccess
+public class LongUnsafe extends AbstractStridedUnsafeLongAccess implements LongLongAccess, VolatileLongAccess
 {
 
 	private final long address;

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/LongUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/LongUnsafe.java
@@ -1,8 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.LongLongAccess;
 
-public class LongUnsafe extends AbstractStridedUnsafeLongAccess implements LongLongAccess
+public class LongUnsafe extends AbstractStridedUnsafeLongAccess implements LongLongAccess, VolatileAccess
 {
 
 	private final long address;
@@ -14,9 +15,19 @@ public class LongUnsafe extends AbstractStridedUnsafeLongAccess implements LongL
 		this( address, null );
 	}
 
+	public LongUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
 	public LongUnsafe( final long address, final Object ownerReference )
 	{
-		super( Long.BYTES );
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	public LongUnsafe( final long address, final Object ownerReference, final boolean isValid )
+	{
+		super( Long.BYTES, isValid );
 		this.address = address;
 		this.ownerReference = ownerReference;
 	}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/LongUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/LongUnsafe.java
@@ -61,4 +61,18 @@ public class LongUnsafe extends AbstractStridedUnsafeLongAccess implements LongL
 		return address;
 	}
 
+	@Override
+	public void finalize() throws Throwable
+	{
+		try
+		{
+			if ( this.ownerReference instanceof Runnable )
+				( ( Runnable ) ownerReference ).run();
+		}
+		finally
+		{
+			super.finalize();
+		}
+	}
+
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ShortUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ShortUnsafe.java
@@ -1,8 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.ShortLongAccess;
 
-public class ShortUnsafe extends AbstractStridedUnsafeLongAccess implements ShortLongAccess
+public class ShortUnsafe extends AbstractStridedUnsafeLongAccess implements ShortLongAccess, VolatileAccess
 {
 
 	private final long address;
@@ -14,9 +15,19 @@ public class ShortUnsafe extends AbstractStridedUnsafeLongAccess implements Shor
 		this( address, null );
 	}
 
+	public ShortUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
 	public ShortUnsafe( final long address, final Object ownerReference )
 	{
-		super( Short.BYTES );
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	public ShortUnsafe( final long address, final Object ownerReference, final boolean isValid )
+	{
+		super( Short.BYTES, isValid );
 		this.address = address;
 		this.ownerReference = ownerReference;
 	}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ShortUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ShortUnsafe.java
@@ -1,9 +1,9 @@
 package net.imglib2.img.basictypelongaccess.unsafe;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileShortAccess;
 import net.imglib2.img.basictypelongaccess.ShortLongAccess;
 
-public class ShortUnsafe extends AbstractStridedUnsafeLongAccess implements ShortLongAccess, VolatileAccess
+public class ShortUnsafe extends AbstractStridedUnsafeLongAccess implements ShortLongAccess, VolatileShortAccess
 {
 
 	private final long address;

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ShortUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ShortUnsafe.java
@@ -61,4 +61,18 @@ public class ShortUnsafe extends AbstractStridedUnsafeLongAccess implements Shor
 		return address;
 	}
 
+	@Override
+	public void finalize() throws Throwable
+	{
+		try
+		{
+			if ( this.ownerReference instanceof Runnable )
+				( ( Runnable ) ownerReference ).run();
+		}
+		finally
+		{
+			super.finalize();
+		}
+	}
+
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningByteUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningByteUnsafe.java
@@ -1,23 +1,30 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.ByteLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.ByteUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningByteUnsafe extends AbstractOwningUnsafe implements ByteLongAccess, UnsafeAccess< OwningByteUnsafe >
+public class OwningByteUnsafe extends AbstractOwningUnsafe implements ByteLongAccess, UnsafeAccess< OwningByteUnsafe >, VolatileAccess
 {
+	private static final boolean DEFAULT_IS_VALID = true;
 
 	private final ByteUnsafe unsafe;
 
-	private final long numEntitites;
+	private final long numEntities;
 
 	public OwningByteUnsafe( final long numEntities )
 	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public OwningByteUnsafe( final long numEntities, final boolean isValid )
+	{
 		super( UnsafeUtil.create( numEntities ) );
-		this.unsafe = new ByteUnsafe( owner.getAddress(), this );
-		this.numEntitites = numEntities;
+		this.unsafe = new ByteUnsafe( owner.getAddress(), this, isValid );
+		this.numEntities = numEntities;
 	}
 
 	@Override
@@ -47,7 +54,7 @@ public class OwningByteUnsafe extends AbstractOwningUnsafe implements ByteLongAc
 	@Override
 	public OwningByteUnsafe createAccess( final long numEntities )
 	{
-		return new OwningByteUnsafe( numEntities );
+		return new OwningByteUnsafe( numEntities, isValid() );
 	}
 
 	@Override
@@ -59,7 +66,13 @@ public class OwningByteUnsafe extends AbstractOwningUnsafe implements ByteLongAc
 	@Override
 	public long getSize()
 	{
-		return this.numEntitites;
+		return this.numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningByteUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningByteUnsafe.java
@@ -1,13 +1,13 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileByteAccess;
 import net.imglib2.img.basictypelongaccess.ByteLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.ByteUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningByteUnsafe extends AbstractOwningUnsafe implements ByteLongAccess, UnsafeAccess< OwningByteUnsafe >, VolatileAccess
+public class OwningByteUnsafe extends AbstractOwningUnsafe implements ByteLongAccess, UnsafeAccess< OwningByteUnsafe >, VolatileByteAccess
 {
 	private static final boolean DEFAULT_IS_VALID = true;
 

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningCharUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningCharUnsafe.java
@@ -1,13 +1,16 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.CharLongAccess;
+import net.imglib2.img.basictypelongaccess.unsafe.ByteUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.CharUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningCharUnsafe extends AbstractOwningUnsafe implements CharLongAccess, UnsafeAccess< OwningCharUnsafe >
+public class OwningCharUnsafe extends AbstractOwningUnsafe implements CharLongAccess, UnsafeAccess< OwningCharUnsafe >, VolatileAccess
 {
+	private static final boolean DEFAULT_IS_VALID = true;
 
 	private final CharUnsafe unsafe;
 
@@ -15,8 +18,13 @@ public class OwningCharUnsafe extends AbstractOwningUnsafe implements CharLongAc
 
 	public OwningCharUnsafe( final long numEntities )
 	{
-		super( UnsafeUtil.create( numEntities * Character.BYTES ) );
-		this.unsafe = new CharUnsafe( owner.getAddress(), this );
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public OwningCharUnsafe( final long numEntities, final boolean isValid )
+	{
+		super( UnsafeUtil.create( numEntities ) );
+		this.unsafe = new CharUnsafe( owner.getAddress(), this, isValid );
 		this.numEntities = numEntities;
 	}
 
@@ -47,7 +55,7 @@ public class OwningCharUnsafe extends AbstractOwningUnsafe implements CharLongAc
 	@Override
 	public OwningCharUnsafe createAccess( final long numEntities )
 	{
-		return new OwningCharUnsafe( numEntities );
+		return new OwningCharUnsafe( numEntities, isValid() );
 	}
 
 	@Override
@@ -60,6 +68,12 @@ public class OwningCharUnsafe extends AbstractOwningUnsafe implements CharLongAc
 	public long getSize()
 	{
 		return numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningCharUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningCharUnsafe.java
@@ -1,14 +1,13 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileCharAccess;
 import net.imglib2.img.basictypelongaccess.CharLongAccess;
-import net.imglib2.img.basictypelongaccess.unsafe.ByteUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.CharUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningCharUnsafe extends AbstractOwningUnsafe implements CharLongAccess, UnsafeAccess< OwningCharUnsafe >, VolatileAccess
+public class OwningCharUnsafe extends AbstractOwningUnsafe implements CharLongAccess, UnsafeAccess< OwningCharUnsafe >, VolatileCharAccess
 {
 	private static final boolean DEFAULT_IS_VALID = true;
 

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningDoubleUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningDoubleUnsafe.java
@@ -1,22 +1,29 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.DoubleLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.DoubleUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningDoubleUnsafe extends AbstractOwningUnsafe implements DoubleLongAccess, UnsafeAccess< OwningDoubleUnsafe >
+public class OwningDoubleUnsafe extends AbstractOwningUnsafe implements DoubleLongAccess, UnsafeAccess< OwningDoubleUnsafe >, VolatileAccess
 {
+	private static final boolean DEFAULT_IS_VALID = true;
 
 	private final DoubleUnsafe unsafe;
 
 	private final long numEntities;
 
-	public OwningDoubleUnsafe( final long numEntities )
+	public OwningDoubleUnsafe( final long numEntities  )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public OwningDoubleUnsafe( final long numEntities, final boolean isValid )
 	{
 		super( UnsafeUtil.create( numEntities * Double.BYTES ) );
-		this.unsafe = new DoubleUnsafe( owner.getAddress(), this );
+		this.unsafe = new DoubleUnsafe( owner.getAddress(), this, isValid );
 		this.numEntities = numEntities;
 	}
 
@@ -47,7 +54,7 @@ public class OwningDoubleUnsafe extends AbstractOwningUnsafe implements DoubleLo
 	@Override
 	public OwningDoubleUnsafe createAccess( final long numEntities )
 	{
-		return new OwningDoubleUnsafe( numEntities );
+		return new OwningDoubleUnsafe( numEntities, unsafe.isValid() );
 	}
 
 	@Override
@@ -60,6 +67,12 @@ public class OwningDoubleUnsafe extends AbstractOwningUnsafe implements DoubleLo
 	public long getSize()
 	{
 		return numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningDoubleUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningDoubleUnsafe.java
@@ -1,13 +1,13 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileDoubleAccess;
 import net.imglib2.img.basictypelongaccess.DoubleLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.DoubleUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningDoubleUnsafe extends AbstractOwningUnsafe implements DoubleLongAccess, UnsafeAccess< OwningDoubleUnsafe >, VolatileAccess
+public class OwningDoubleUnsafe extends AbstractOwningUnsafe implements DoubleLongAccess, UnsafeAccess< OwningDoubleUnsafe >, VolatileDoubleAccess
 {
 	private static final boolean DEFAULT_IS_VALID = true;
 

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningFloatUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningFloatUnsafe.java
@@ -1,23 +1,30 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.FloatLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.FloatUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningFloatUnsafe extends AbstractOwningUnsafe implements FloatLongAccess, UnsafeAccess< OwningFloatUnsafe >
+public class OwningFloatUnsafe extends AbstractOwningUnsafe implements FloatLongAccess, UnsafeAccess< OwningFloatUnsafe >, VolatileAccess
 {
+	private static final boolean DEFAULT_IS_VALID = true;
 
 	private final FloatUnsafe unsafe;
 
 	private final long numEntities;
 
-	public OwningFloatUnsafe( final long numEntitites )
+	public OwningFloatUnsafe( final long numEntities )
 	{
-		super( UnsafeUtil.create( numEntitites * Float.BYTES ) );
-		this.unsafe = new FloatUnsafe( owner.getAddress(), this );
-		this.numEntities = numEntitites;
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public OwningFloatUnsafe( final long numEntities, final boolean isValid )
+	{
+		super( UnsafeUtil.create( numEntities * Float.BYTES ) );
+		this.unsafe = new FloatUnsafe( owner.getAddress(), this, isValid );
+		this.numEntities = numEntities;
 	}
 
 	@Override
@@ -47,7 +54,7 @@ public class OwningFloatUnsafe extends AbstractOwningUnsafe implements FloatLong
 	@Override
 	public OwningFloatUnsafe createAccess( final long numEntities )
 	{
-		return new OwningFloatUnsafe( numEntities );
+		return new OwningFloatUnsafe( numEntities, isValid() );
 	}
 
 	@Override
@@ -60,6 +67,12 @@ public class OwningFloatUnsafe extends AbstractOwningUnsafe implements FloatLong
 	public long getSize()
 	{
 		return numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningFloatUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningFloatUnsafe.java
@@ -1,13 +1,13 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileFloatAccess;
 import net.imglib2.img.basictypelongaccess.FloatLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.FloatUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningFloatUnsafe extends AbstractOwningUnsafe implements FloatLongAccess, UnsafeAccess< OwningFloatUnsafe >, VolatileAccess
+public class OwningFloatUnsafe extends AbstractOwningUnsafe implements FloatLongAccess, UnsafeAccess< OwningFloatUnsafe >, VolatileFloatAccess
 {
 	private static final boolean DEFAULT_IS_VALID = true;
 

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningIntUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningIntUnsafe.java
@@ -1,13 +1,13 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileIntAccess;
 import net.imglib2.img.basictypelongaccess.IntLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.IntUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningIntUnsafe extends AbstractOwningUnsafe implements IntLongAccess, UnsafeAccess< OwningIntUnsafe >, VolatileAccess
+public class OwningIntUnsafe extends AbstractOwningUnsafe implements IntLongAccess, UnsafeAccess< OwningIntUnsafe >, VolatileIntAccess
 {
 	private static final boolean DEFAULT_IS_VALID = true;
 

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningIntUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningIntUnsafe.java
@@ -1,13 +1,15 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.IntLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.IntUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningIntUnsafe extends AbstractOwningUnsafe implements IntLongAccess, UnsafeAccess< OwningIntUnsafe >
+public class OwningIntUnsafe extends AbstractOwningUnsafe implements IntLongAccess, UnsafeAccess< OwningIntUnsafe >, VolatileAccess
 {
+	private static final boolean DEFAULT_IS_VALID = true;
 
 	private final IntUnsafe unsafe;
 
@@ -15,8 +17,13 @@ public class OwningIntUnsafe extends AbstractOwningUnsafe implements IntLongAcce
 
 	public OwningIntUnsafe( final long numEntities )
 	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public OwningIntUnsafe( final long numEntities, final boolean isValid )
+	{
 		super( UnsafeUtil.create( numEntities * Integer.BYTES ) );
-		this.unsafe = new IntUnsafe( owner.getAddress(), this );
+		this.unsafe = new IntUnsafe( owner.getAddress(), this, isValid );
 		this.numEntities = numEntities;
 	}
 
@@ -47,7 +54,7 @@ public class OwningIntUnsafe extends AbstractOwningUnsafe implements IntLongAcce
 	@Override
 	public OwningIntUnsafe createAccess( final long numEntities )
 	{
-		return new OwningIntUnsafe( numEntities );
+		return new OwningIntUnsafe( numEntities, isValid() );
 	}
 
 	@Override
@@ -60,6 +67,12 @@ public class OwningIntUnsafe extends AbstractOwningUnsafe implements IntLongAcce
 	public long getSize()
 	{
 		return numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningLongUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningLongUnsafe.java
@@ -1,13 +1,13 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileLongAccess;
 import net.imglib2.img.basictypelongaccess.LongLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.LongUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningLongUnsafe extends AbstractOwningUnsafe implements LongLongAccess, UnsafeAccess< OwningLongUnsafe >, VolatileAccess
+public class OwningLongUnsafe extends AbstractOwningUnsafe implements LongLongAccess, UnsafeAccess< OwningLongUnsafe >, VolatileLongAccess
 {
 	private static final boolean DEFAULT_IS_VALID = true;
 

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningLongUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningLongUnsafe.java
@@ -1,13 +1,15 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.LongLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.LongUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningLongUnsafe extends AbstractOwningUnsafe implements LongLongAccess, UnsafeAccess< OwningLongUnsafe >
+public class OwningLongUnsafe extends AbstractOwningUnsafe implements LongLongAccess, UnsafeAccess< OwningLongUnsafe >, VolatileAccess
 {
+	private static final boolean DEFAULT_IS_VALID = true;
 
 	private final LongUnsafe unsafe;
 
@@ -15,8 +17,13 @@ public class OwningLongUnsafe extends AbstractOwningUnsafe implements LongLongAc
 
 	public OwningLongUnsafe( final long numEntities )
 	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public OwningLongUnsafe( final long numEntities, final boolean isValid )
+	{
 		super( UnsafeUtil.create( numEntities * Integer.BYTES ) );
-		this.unsafe = new LongUnsafe( owner.getAddress(), this );
+		this.unsafe = new LongUnsafe( owner.getAddress(), this, isValid );
 		this.numEntities = numEntities;
 	}
 
@@ -47,7 +54,7 @@ public class OwningLongUnsafe extends AbstractOwningUnsafe implements LongLongAc
 	@Override
 	public OwningLongUnsafe createAccess( final long numEntities )
 	{
-		return new OwningLongUnsafe( numEntities );
+		return new OwningLongUnsafe( numEntities, isValid() );
 	}
 
 	@Override
@@ -60,6 +67,12 @@ public class OwningLongUnsafe extends AbstractOwningUnsafe implements LongLongAc
 	public long getSize()
 	{
 		return numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningShortUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningShortUnsafe.java
@@ -1,13 +1,15 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
+import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
 import net.imglib2.img.basictypelongaccess.ShortLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.ShortUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningShortUnsafe extends AbstractOwningUnsafe implements ShortLongAccess, UnsafeAccess< OwningShortUnsafe >
+public class OwningShortUnsafe extends AbstractOwningUnsafe implements ShortLongAccess, UnsafeAccess< OwningShortUnsafe >, VolatileAccess
 {
+	private static final boolean DEFAULT_IS_VALID = true;
 
 	private final ShortUnsafe unsafe;
 
@@ -15,8 +17,13 @@ public class OwningShortUnsafe extends AbstractOwningUnsafe implements ShortLong
 
 	public OwningShortUnsafe( final long numEntities )
 	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public OwningShortUnsafe( final long numEntities, final boolean isValid )
+	{
 		super( UnsafeUtil.create( numEntities * Integer.BYTES ) );
-		this.unsafe = new ShortUnsafe( owner.getAddress(), this );
+		this.unsafe = new ShortUnsafe( owner.getAddress(), this, isValid );
 		this.numEntities = numEntities;
 	}
 
@@ -47,7 +54,7 @@ public class OwningShortUnsafe extends AbstractOwningUnsafe implements ShortLong
 	@Override
 	public OwningShortUnsafe createAccess( final long numEntities )
 	{
-		return new OwningShortUnsafe( numEntities );
+		return new OwningShortUnsafe( numEntities, isValid() );
 	}
 
 	@Override
@@ -60,6 +67,12 @@ public class OwningShortUnsafe extends AbstractOwningUnsafe implements ShortLong
 	public long getSize()
 	{
 		return this.numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
 	}
 
 }

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningShortUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningShortUnsafe.java
@@ -1,13 +1,13 @@
 package net.imglib2.img.basictypelongaccess.unsafe.owning;
 
-import net.imglib2.img.basictypeaccess.volatiles.VolatileAccess;
+import net.imglib2.img.basictypeaccess.volatiles.VolatileShortAccess;
 import net.imglib2.img.basictypelongaccess.ShortLongAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.ShortUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
-public class OwningShortUnsafe extends AbstractOwningUnsafe implements ShortLongAccess, UnsafeAccess< OwningShortUnsafe >, VolatileAccess
+public class OwningShortUnsafe extends AbstractOwningUnsafe implements ShortLongAccess, UnsafeAccess< OwningShortUnsafe >, VolatileShortAccess
 {
 	private static final boolean DEFAULT_IS_VALID = true;
 


### PR DESCRIPTION
 1. Make all unsafe accesses volatile: This does not any overhead, and it will be necessary for wrapping into volatile type images to avoid blocking when looking at data through BDV
 2. Override `finalize` for all unsafe accesses to allow to execute a `Runnable` when object is garbage collected. This is necessary for memory management: Python objects may be garbage collected while still being used inside the JVM (https://github.com/kivy/pyjnius/issues/345). To avoid this, keep references to Python objects in a global (compared to the scope of use) store. the `Runnable` can remove this reference after garbage collection on the JVM side.