### PR TITLE
Add support for Booleans

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 - 2021, Howard Hughes Medical Institute.
+Copyright (c) 2017 - 2023, Howard Hughes Medical Institute.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/pom.xml
+++ b/pom.xml
@@ -98,5 +98,13 @@
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
 		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/src/main/java/net/imglib2/converter/longaccess/ARGBConverter.java
+++ b/src/main/java/net/imglib2/converter/longaccess/ARGBConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/longaccess/FloatConverter.java
+++ b/src/main/java/net/imglib2/converter/longaccess/FloatConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/ARGBLongAccessTypeARGBTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/ARGBLongAccessTypeARGBTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/ByteLongAccessTypeByteTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/ByteLongAccessTypeByteTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/ByteLongAccessTypeNativeBoolTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/ByteLongAccessTypeNativeBoolTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/ByteLongAccessTypeNativeBoolTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/ByteLongAccessTypeNativeBoolTypeConverter.java
@@ -1,0 +1,83 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.converter.readwrite.longaccess;
+
+import net.imglib2.Sampler;
+import net.imglib2.converter.readwrite.SamplerConverter;
+import net.imglib2.img.basictypeaccess.BooleanAccess;
+import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.integer.ByteLongAccessType;
+import net.imglib2.type.numeric.integer.ByteType;
+
+/**
+ * A {@link SamplerConverter} that converts {@link ByteLongAccessType} into
+ * {@link NativeBoolType}. {@link NativeBoolType}s are fundamentally 8 bits,
+ * which is also the size of a {@link ByteType}; even sizes make this conversion
+ * sensical.
+ * 
+ * @author Gabriel Selzer
+ */
+public class ByteLongAccessTypeNativeBoolTypeConverter implements SamplerConverter< ByteLongAccessType, NativeBoolType >
+{
+
+	@Override
+	public NativeBoolType convert( final Sampler< ? extends ByteLongAccessType > sampler )
+	{
+		return new NativeBoolType( new ConvertedAccess( sampler.get() ) );
+	}
+
+	public static class ConvertedAccess implements BooleanAccess
+	{
+		private static final byte ONE = ( byte ) 1;
+
+		private static final byte ZERO = ( byte ) 0;
+
+		private final ByteLongAccessType type;
+
+		public ConvertedAccess( final ByteLongAccessType type )
+		{
+			this.type = type;
+		}
+
+		@Override
+		public boolean getValue( final int index )
+		{
+			return type.get() > 0;
+		}
+
+		@Override
+		public void setValue( final int index, final boolean value )
+		{
+			type.set( value ? ONE : ZERO );
+		}
+
+	}
+
+}

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/ComplexDoubleLongAccessTypeComplexDoubleTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/ComplexDoubleLongAccessTypeComplexDoubleTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/ComplexFloatLongAccessTypeComplexFloatTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/ComplexFloatLongAccessTypeComplexFloatTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/DoubleLongAccessTypeDoubleTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/DoubleLongAccessTypeDoubleTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/FloatLongAccessTypeFloatTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/FloatLongAccessTypeFloatTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/IntLongAccessTypeIntTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/IntLongAccessTypeIntTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/LongLongAccessTypeLongTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/LongLongAccessTypeLongTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/ShortLongAccessTypeShortTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/ShortLongAccessTypeShortTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/UnsignedByteLongAccessTypeUnsignedByteTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/UnsignedByteLongAccessTypeUnsignedByteTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/UnsignedIntLongAccessTypeUnsignedIntTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/UnsignedIntLongAccessTypeUnsignedIntTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/UnsignedLongLongAccessTypeUnsignedLongTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/UnsignedLongLongAccessTypeUnsignedLongTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/converter/readwrite/longaccess/UnsignedShortLongAccessTypeUnsignedShortTypeConverter.java
+++ b/src/main/java/net/imglib2/converter/readwrite/longaccess/UnsignedShortLongAccessTypeUnsignedShortTypeConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/AbstractNativeLongAccessImg.java
+++ b/src/main/java/net/imglib2/img/AbstractNativeLongAccessImg.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/NativeLongAccessImg.java
+++ b/src/main/java/net/imglib2/img/NativeLongAccessImg.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/NativeLongAccessImgFactory.java
+++ b/src/main/java/net/imglib2/img/NativeLongAccessImgFactory.java
@@ -68,6 +68,7 @@ public abstract class NativeLongAccessImgFactory< T extends NativeLongAccessType
 		return type.createSuitableNativeImg( this, dim );
 	}
 
+	public abstract NativeLongAccessImg< T, ? extends BooleanLongAccess> createNativeBooleanInstance( long[] dimensions, Fraction entitiesPerPixel );
 	/* basic type containers */
 	public abstract NativeLongAccessImg< T, ? extends ByteLongAccess > createByteInstance( long[] dimensions, Fraction entitiesPerPixel );
 

--- a/src/main/java/net/imglib2/img/NativeLongAccessImgFactory.java
+++ b/src/main/java/net/imglib2/img/NativeLongAccessImgFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/NativeLongAccessImgFactory.java
+++ b/src/main/java/net/imglib2/img/NativeLongAccessImgFactory.java
@@ -68,8 +68,9 @@ public abstract class NativeLongAccessImgFactory< T extends NativeLongAccessType
 		return type.createSuitableNativeImg( this, dim );
 	}
 
-	public abstract NativeLongAccessImg< T, ? extends BooleanLongAccess> createNativeBooleanInstance( long[] dimensions, Fraction entitiesPerPixel );
 	/* basic type containers */
+	public abstract NativeLongAccessImg< T, ? extends BooleanLongAccess> createNativeBooleanInstance( long[] dimensions, Fraction entitiesPerPixel );
+
 	public abstract NativeLongAccessImg< T, ? extends ByteLongAccess > createByteInstance( long[] dimensions, Fraction entitiesPerPixel );
 
 	public abstract NativeLongAccessImg< T, ? extends CharLongAccess > createCharInstance( long[] dimensions, Fraction entitiesPerPixel );

--- a/src/main/java/net/imglib2/img/NativeLongAccessImgFactory.java
+++ b/src/main/java/net/imglib2/img/NativeLongAccessImgFactory.java
@@ -29,6 +29,7 @@
 
 package net.imglib2.img;
 
+import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
 import net.imglib2.img.basictypelongaccess.ByteLongAccess;
 import net.imglib2.img.basictypelongaccess.CharLongAccess;
 import net.imglib2.img.basictypelongaccess.DoubleLongAccess;

--- a/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
+++ b/src/main/java/net/imglib2/img/basictypeaccess/Accesses.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/BooleanLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/BooleanLongAccess.java
@@ -2,17 +2,17 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/main/java/net/imglib2/img/basictypelongaccess/BooleanLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/BooleanLongAccess.java
@@ -32,7 +32,8 @@ package net.imglib2.img.basictypelongaccess;
 import net.imglib2.img.basictypeaccess.BooleanAccess;
 
 /**
- * TODO
+ * A {@link BooleanAccess} that can also query indices representable by a
+ * {@code long}
  *
  * @author Gabriel Selzer
  */

--- a/src/main/java/net/imglib2/img/basictypelongaccess/BooleanLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/BooleanLongAccess.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.basictypelongaccess;
+
+import net.imglib2.img.basictypeaccess.BooleanAccess;
+
+/**
+ * TODO
+ *
+ * @author Gabriel Selzer
+ */
+public interface BooleanLongAccess extends BooleanAccess
+{
+	public boolean getValue( final long index );
+
+	public void setValue( final long index, final boolean value );
+}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/ByteLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/ByteLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/ByteLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/ByteLongAccess.java
@@ -32,7 +32,8 @@ package net.imglib2.img.basictypelongaccess;
 import net.imglib2.img.basictypeaccess.ByteAccess;
 
 /**
- * TODO
+ * A {@link ByteAccess} that can also query indices representable by a
+ * {@code long}
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/CharLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/CharLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/CharLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/CharLongAccess.java
@@ -32,7 +32,8 @@ package net.imglib2.img.basictypelongaccess;
 import net.imglib2.img.basictypeaccess.CharAccess;
 
 /**
- * TODO
+ * A {@link CharAccess} that can also query indices representable by a
+ * {@code long}
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/DoubleLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/DoubleLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/DoubleLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/DoubleLongAccess.java
@@ -32,7 +32,8 @@ package net.imglib2.img.basictypelongaccess;
 import net.imglib2.img.basictypeaccess.DoubleAccess;
 
 /**
- * TODO
+ * A {@link DoubleAccess} that can also query indices representable by a
+ * {@code long}
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/FloatLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/FloatLongAccess.java
@@ -32,7 +32,8 @@ package net.imglib2.img.basictypelongaccess;
 import net.imglib2.img.basictypeaccess.FloatAccess;
 
 /**
- * TODO
+ * A {@link FloatAccess} that can also query indices representable by a
+ * {@code long}
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/FloatLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/FloatLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/IntLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/IntLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/IntLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/IntLongAccess.java
@@ -32,7 +32,8 @@ package net.imglib2.img.basictypelongaccess;
 import net.imglib2.img.basictypeaccess.IntAccess;
 
 /**
- * TODO
+ * A {@link IntAccess} that can also query indices representable by a
+ * {@code long}
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/LongLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/LongLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/LongLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/LongLongAccess.java
@@ -32,7 +32,8 @@ package net.imglib2.img.basictypelongaccess;
 import net.imglib2.img.basictypeaccess.LongAccess;
 
 /**
- * TODO
+ * A {@link LongAccess} that can also query indices representable by a
+ * {@code long}
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/ShortLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/ShortLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/ShortLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/ShortLongAccess.java
@@ -32,7 +32,8 @@ package net.imglib2.img.basictypelongaccess;
 import net.imglib2.img.basictypeaccess.ShortAccess;
 
 /**
- * TODO
+ * A {@link ShortAccess} that can also query indices representable by a
+ * {@code long}
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/AbstractStridedUnsafeLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/AbstractStridedUnsafeLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/BooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/BooleanUnsafe.java
@@ -1,0 +1,139 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypelongaccess.unsafe;
+
+import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
+import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
+
+/**
+ * A {@link BooleanLongAccess} that accesses memory, starting from
+ * {@code address}.
+ *
+ * @author Gabriel Selzer
+ */
+public class BooleanUnsafe
+		implements BooleanLongAccess, VolatileBooleanAccess
+{
+	private static final boolean DEFAULT_IS_VALID = true;
+	private static final byte ZERO = (byte) 0;
+	private static final byte ONE = (byte) 1;
+
+	private final ByteUnsafe wrapped;
+
+	public BooleanUnsafe( final long address )
+	{
+		this( address, null );
+	}
+
+	public BooleanUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
+	public BooleanUnsafe( final long address, final Object ownerReference )
+	{
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	/**
+	 * Standard {@link BooleanUnsafe} constructor.
+	 * 
+	 * @param address
+	 *            the address in memory to index from
+	 * @param ownerReference
+	 *            a reference to another {@link Object} that can hold control
+	 *            over the memory starting at {@code address}. Can be used to
+	 *            ensure that the backing memory is <b>not</b>
+	 *            garbage-collected.
+	 * @param isValid
+	 *            - denotes the validity of this {@link BooleanUnsafe}
+	 */
+	public BooleanUnsafe( final long address, final Object ownerReference, final boolean isValid )
+	{
+		super();
+		this.wrapped = new ByteUnsafe(address, ownerReference, isValid);
+	}
+
+	@Override
+	public boolean getValue( final int index )
+	{
+		return getValue( ( long ) index );
+	}
+
+	@Override
+	public void setValue( final int index, final boolean value )
+	{
+		setValue( ( long ) index, value );
+	}
+
+	/**
+	 * Returns the boolean value at {@code index}.
+	 * 
+	 * @param index
+	 *            the offset (in bytes) from {@code address}.
+	 * @return the value at {@code index}
+	 */
+	@Override
+	public boolean getValue( final long index )
+	{
+		return wrapped.getValue(index) > 0;
+	}
+
+	/**
+	 * Sets the value at {@code index}.
+	 * 
+	 * @param index
+	 *            the offset (in bytes) from {@code address}
+	 * @param value
+	 *            the boolean value to be set at {@code index}
+	 */
+	@Override
+	public void setValue( final long index, final boolean value )
+	{
+		wrapped.setValue(index, value ? ONE : ZERO);
+	}
+
+	public long getAddres()
+	{
+		return wrapped.getAddres();
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return wrapped.isValid();
+	}
+
+	@Override
+	public void finalize() throws Throwable
+	{
+		wrapped.finalize();
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ByteUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ByteUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/CharUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/CharUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/DoubleUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/DoubleUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/FloatUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/FloatUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/IntUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/IntUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/LongUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/LongUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/NativeBooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/NativeBooleanUnsafe.java
@@ -31,6 +31,9 @@ package net.imglib2.img.basictypelongaccess.unsafe;
 import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
 import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
 
+/**
+ * @author Gabriel Selzer
+ */
 public class NativeBooleanUnsafe
 		implements BooleanLongAccess, VolatileBooleanAccess
 {

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/NativeBooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/NativeBooleanUnsafe.java
@@ -32,6 +32,9 @@ import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
 import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
 
 /**
+ * A {@link BooleanLongAccess} that accesses memory, starting from
+ * {@code address}.
+ *
  * @author Gabriel Selzer
  */
 public class NativeBooleanUnsafe
@@ -58,6 +61,19 @@ public class NativeBooleanUnsafe
 		this( address, ownerReference, DEFAULT_IS_VALID );
 	}
 
+	/**
+	 * Standard {@link NativeBooleanUnsafe} constructor.
+	 * 
+	 * @param address
+	 *            the address in memory to index from
+	 * @param ownerReference
+	 *            a reference to another {@link Object} that can hold control
+	 *            over the memory starting at {@code address}. Can be used to
+	 *            ensure that the backing memory is <b>not</b>
+	 *            garbage-collected.
+	 * @param isValid
+	 *            - denotes the validity of this {@link NativeBooleanUnsafe}
+	 */
 	public NativeBooleanUnsafe( final long address, final Object ownerReference, final boolean isValid )
 	{
 		super();
@@ -76,12 +92,27 @@ public class NativeBooleanUnsafe
 		setValue( ( long ) index, value );
 	}
 
+	/**
+	 * Returns the boolean value at {@code index}.
+	 * 
+	 * @param index
+	 *            the offset (in bytes) from {@code address}.
+	 * @return the value at {@code index}
+	 */
 	@Override
 	public boolean getValue( final long index )
 	{
 		return wrapped.getValue(index) > 0;
 	}
 
+	/**
+	 * Sets the value at {@code index}.
+	 * 
+	 * @param index
+	 *            the offset (in bytes) from {@code address}
+	 * @param value
+	 *            the boolean value to be set at {@code index}
+	 */
 	@Override
 	public void setValue( final long index, final boolean value )
 	{

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/NativeBooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/NativeBooleanUnsafe.java
@@ -2,17 +2,17 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/NativeBooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/NativeBooleanUnsafe.java
@@ -1,0 +1,105 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypelongaccess.unsafe;
+
+import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
+import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
+
+public class NativeBooleanUnsafe
+		implements BooleanLongAccess, VolatileBooleanAccess
+{
+	private static final boolean DEFAULT_IS_VALID = true;
+	private static final byte ZERO = (byte) 0;
+	private static final byte ONE = (byte) 1;
+
+	private final ByteUnsafe wrapped;
+
+	public NativeBooleanUnsafe( final long address )
+	{
+		this( address, null );
+	}
+
+	public NativeBooleanUnsafe( final long address, final boolean isValid )
+	{
+		this( address, null, isValid );
+	}
+
+	public NativeBooleanUnsafe( final long address, final Object ownerReference )
+	{
+		this( address, ownerReference, DEFAULT_IS_VALID );
+	}
+
+	public NativeBooleanUnsafe( final long address, final Object ownerReference, final boolean isValid )
+	{
+		super();
+		this.wrapped = new ByteUnsafe(address, ownerReference, isValid);
+	}
+
+	@Override
+	public boolean getValue( final int index )
+	{
+		return getValue( ( long ) index );
+	}
+
+	@Override
+	public void setValue( final int index, final boolean value )
+	{
+		setValue( ( long ) index, value );
+	}
+
+	@Override
+	public boolean getValue( final long index )
+	{
+		return wrapped.getValue(index) > 0;
+	}
+
+	@Override
+	public void setValue( final long index, final boolean value )
+	{
+		wrapped.setValue(index, value ? ONE : ZERO);
+	}
+
+	public long getAddres()
+	{
+		return wrapped.getAddres();
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return wrapped.isValid();
+	}
+
+	@Override
+	public void finalize() throws Throwable
+	{
+		wrapped.finalize();
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ShortUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/ShortUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/UnsafeAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/UnsafeAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/UnsafeAccessFactory.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/UnsafeAccessFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/UnsafeUtil.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/UnsafeUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/AbstractOwningUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/AbstractOwningUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningBooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningBooleanUnsafe.java
@@ -1,0 +1,122 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypelongaccess.unsafe.owning;
+
+import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
+import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
+import net.imglib2.img.basictypelongaccess.unsafe.BooleanUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+import net.imglib2.type.PrimitiveType;
+
+/**
+ * A convenience wrapper for {@link BooleanUnsafe} that uses itself as the
+ * owner of the memory accessed.
+ * 
+ * @author Gabriel Selzer
+ */
+public class OwningBooleanUnsafe extends AbstractOwningUnsafe implements
+		BooleanLongAccess, UnsafeAccess<OwningBooleanUnsafe>,
+		VolatileBooleanAccess
+{
+	private static final boolean DEFAULT_IS_VALID = true;
+
+	private final BooleanUnsafe unsafe;
+
+	private final long numEntities;
+
+	public OwningBooleanUnsafe( final long numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	/**
+	 * The default {@link OwningBooleanUnsafe} constructor
+	 * 
+	 * @param numEntities
+	 *            the size (in number of indices) of the backing memory.
+	 * @param isValid
+	 *            the validity of this {@link OwningBooleanUnsafe}
+	 */
+	public OwningBooleanUnsafe( final long numEntities, final boolean isValid )
+	{
+		super( UnsafeUtil.create( numEntities ) );
+		this.unsafe = new BooleanUnsafe( owner.getAddress(), this, isValid );
+		this.numEntities = numEntities;
+	}
+
+	@Override
+	public boolean getValue( final int index )
+	{
+		return unsafe.getValue( index );
+	}
+
+	@Override
+	public void setValue( final int index, final boolean value )
+	{
+		unsafe.setValue( index, value );
+	}
+
+	@Override
+	public boolean getValue( final long index )
+	{
+		return unsafe.getValue( index );
+	}
+
+	@Override
+	public void setValue( final long index, final boolean value )
+	{
+		unsafe.setValue( index, value );
+	}
+
+	@Override
+	public OwningBooleanUnsafe createAccess( final long numEntities )
+	{
+		return new OwningBooleanUnsafe( numEntities, isValid() );
+	}
+
+	@Override
+	public PrimitiveType getType()
+	{
+		return PrimitiveType.BYTE;
+	}
+
+	@Override
+	public long getSize()
+	{
+		return this.numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningByteUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningByteUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningCharUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningCharUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningDoubleUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningDoubleUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningFloatUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningFloatUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningIntUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningIntUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningLongUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningLongUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningNativeBooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningNativeBooleanUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningNativeBooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningNativeBooleanUnsafe.java
@@ -35,6 +35,12 @@ import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
 import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
 import net.imglib2.type.PrimitiveType;
 
+/**
+ * A convenience wrapper for {@link NativeBooleanUnsafe} that uses itself as the
+ * owner of the memory accessed.
+ * 
+ * @author Gabriel Selzer
+ */
 public class OwningNativeBooleanUnsafe extends AbstractOwningUnsafe implements
 		BooleanLongAccess, UnsafeAccess<OwningNativeBooleanUnsafe>,
 		VolatileBooleanAccess
@@ -50,6 +56,14 @@ public class OwningNativeBooleanUnsafe extends AbstractOwningUnsafe implements
 		this( numEntities, DEFAULT_IS_VALID );
 	}
 
+	/**
+	 * The default {@link OwningNativeBooleanUnsafe} constructor
+	 * 
+	 * @param numEntities
+	 *            the size (in number of indices) of the backing memory.
+	 * @param isValid
+	 *            the validity of this {@link OwningNativeBooleanUnsafe}
+	 */
 	public OwningNativeBooleanUnsafe( final long numEntities, final boolean isValid )
 	{
 		super( UnsafeUtil.create( numEntities ) );

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningNativeBooleanUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningNativeBooleanUnsafe.java
@@ -1,0 +1,108 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypelongaccess.unsafe.owning;
+
+import net.imglib2.img.basictypeaccess.volatiles.VolatileBooleanAccess;
+import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
+import net.imglib2.img.basictypelongaccess.unsafe.NativeBooleanUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeAccess;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+import net.imglib2.type.PrimitiveType;
+
+public class OwningNativeBooleanUnsafe extends AbstractOwningUnsafe implements
+		BooleanLongAccess, UnsafeAccess<OwningNativeBooleanUnsafe>,
+		VolatileBooleanAccess
+{
+	private static final boolean DEFAULT_IS_VALID = true;
+
+	private final NativeBooleanUnsafe unsafe;
+
+	private final long numEntities;
+
+	public OwningNativeBooleanUnsafe( final long numEntities )
+	{
+		this( numEntities, DEFAULT_IS_VALID );
+	}
+
+	public OwningNativeBooleanUnsafe( final long numEntities, final boolean isValid )
+	{
+		super( UnsafeUtil.create( numEntities ) );
+		this.unsafe = new NativeBooleanUnsafe( owner.getAddress(), this, isValid );
+		this.numEntities = numEntities;
+	}
+
+	@Override
+	public boolean getValue( final int index )
+	{
+		return unsafe.getValue( index );
+	}
+
+	@Override
+	public void setValue( final int index, final boolean value )
+	{
+		unsafe.setValue( index, value );
+	}
+
+	@Override
+	public boolean getValue( final long index )
+	{
+		return unsafe.getValue( index );
+	}
+
+	@Override
+	public void setValue( final long index, final boolean value )
+	{
+		unsafe.setValue( index, value );
+	}
+
+	@Override
+	public OwningNativeBooleanUnsafe createAccess( final long numEntities )
+	{
+		return new OwningNativeBooleanUnsafe( numEntities, isValid() );
+	}
+
+	@Override
+	public PrimitiveType getType()
+	{
+		return PrimitiveType.BYTE;
+	}
+
+	@Override
+	public long getSize()
+	{
+		return this.numEntities;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return unsafe.isValid();
+	}
+
+}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningShortUnsafe.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/unsafe/owning/OwningShortUnsafe.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedBooleanLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedBooleanLongAccess.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.basictypelongaccess.wrapped;
+
+import net.imglib2.img.basictypeaccess.BooleanAccess;
+import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
+
+/**
+ * A {@link BooleanLongAccess} backed by a {@link BooleanAccess}.
+ *
+ * @author Curtis Rueden
+ */
+public class WrappedBooleanLongAccess< A extends BooleanAccess > implements BooleanLongAccess
+{
+
+	private final A access;
+
+	public WrappedBooleanLongAccess( final A access )
+	{
+		super();
+		this.access = access;
+	}
+
+	@Override
+	public boolean getValue( final long index )
+	{
+		return getValue( ( int ) index );
+	}
+
+	@Override
+	public void setValue( final long index, final boolean value )
+	{
+		setValue( ( int ) index, value );
+	}
+
+	@Override
+	public boolean getValue( final int index )
+	{
+		return access.getValue( index );
+	}
+
+	@Override
+	public void setValue( final int index, final boolean value )
+	{
+		access.setValue( index, value );
+	}
+}

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedByteLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedByteLongAccess.java
@@ -33,7 +33,7 @@ import net.imglib2.img.basictypeaccess.ByteAccess;
 import net.imglib2.img.basictypelongaccess.ByteLongAccess;
 
 /**
- * TODO
+ * A {@link ByteLongAccess} backed by a {@link ByteAccess}.
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedByteLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedByteLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedCharLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedCharLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedCharLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedCharLongAccess.java
@@ -33,7 +33,7 @@ import net.imglib2.img.basictypeaccess.CharAccess;
 import net.imglib2.img.basictypelongaccess.CharLongAccess;
 
 /**
- * TODO
+ * A {@link CharLongAccess} backed by a {@link CharAccess}.
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedDoubleLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedDoubleLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedDoubleLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedDoubleLongAccess.java
@@ -33,7 +33,7 @@ import net.imglib2.img.basictypeaccess.DoubleAccess;
 import net.imglib2.img.basictypelongaccess.DoubleLongAccess;
 
 /**
- * TODO
+ * A {@link DoubleLongAccess} backed by a {@link DoubleAccess}.
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedFloatLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedFloatLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedFloatLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedFloatLongAccess.java
@@ -33,7 +33,7 @@ import net.imglib2.img.basictypeaccess.FloatAccess;
 import net.imglib2.img.basictypelongaccess.FloatLongAccess;
 
 /**
- * TODO
+ * A {@link FloatLongAccess} backed by a {@link FloatAccess}.
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedIntLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedIntLongAccess.java
@@ -33,7 +33,7 @@ import net.imglib2.img.basictypeaccess.IntAccess;
 import net.imglib2.img.basictypelongaccess.IntLongAccess;
 
 /**
- * TODO
+ * An {@link IntLongAccess} backed by an {@link IntAccess}.
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedIntLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedIntLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedLongLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedLongLongAccess.java
@@ -33,7 +33,7 @@ import net.imglib2.img.basictypeaccess.LongAccess;
 import net.imglib2.img.basictypelongaccess.LongLongAccess;
 
 /**
- * TODO
+ * A {@link LongLongAccess} backed by a {@link LongAccess}.
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedLongLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedLongLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedShortLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedShortLongAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedShortLongAccess.java
+++ b/src/main/java/net/imglib2/img/basictypelongaccess/wrapped/WrappedShortLongAccess.java
@@ -33,7 +33,7 @@ import net.imglib2.img.basictypeaccess.ShortAccess;
 import net.imglib2.img.basictypelongaccess.ShortLongAccess;
 
 /**
- * TODO
+ * A {@link ShortLongAccess} backed by a {@link ShortAccess}.
  *
  * @author Stephan Preibisch
  * @author Stephan Saalfeld

--- a/src/main/java/net/imglib2/img/unsafe/AbstractUnsafeCursor.java
+++ b/src/main/java/net/imglib2/img/unsafe/AbstractUnsafeCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/AbstractUnsafeLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/unsafe/AbstractUnsafeLocalizingCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeCursor.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeImg.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeImg.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeImgFactory.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeImgFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeImgFactory.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeImgFactory.java
@@ -42,6 +42,7 @@ import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningDoubleUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningFloatUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningIntUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningLongUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningNativeBooleanUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningShortUnsafe;
 import net.imglib2.type.NativeLongAccessType;
 import net.imglib2.type.NativeLongAccessTypeFactory;
@@ -79,6 +80,14 @@ public class UnsafeImgFactory< T extends NativeLongAccessType< T > > extends Nat
 	{
 		final long numEntities = entitiesPerPixel.mulCeil( AbstractImg.numElements( dimensions ) );
 		return numEntities;
+	}
+
+	@Override
+	public UnsafeImg< T, OwningNativeBooleanUnsafe > createNativeBooleanInstance( final long[] dimensions, final Fraction entitiesPerPixel )
+	{
+		final long numEntities = numEntities( dimensions, entitiesPerPixel );
+
+		return new UnsafeImg<>( new OwningNativeBooleanUnsafe( numEntities ), dimensions, entitiesPerPixel );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeImgFactory.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeImgFactory.java
@@ -42,7 +42,7 @@ import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningDoubleUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningFloatUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningIntUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningLongUnsafe;
-import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningNativeBooleanUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningBooleanUnsafe;
 import net.imglib2.img.basictypelongaccess.unsafe.owning.OwningShortUnsafe;
 import net.imglib2.type.NativeLongAccessType;
 import net.imglib2.type.NativeLongAccessTypeFactory;
@@ -83,11 +83,11 @@ public class UnsafeImgFactory< T extends NativeLongAccessType< T > > extends Nat
 	}
 
 	@Override
-	public UnsafeImg< T, OwningNativeBooleanUnsafe > createNativeBooleanInstance( final long[] dimensions, final Fraction entitiesPerPixel )
+	public UnsafeImg< T, OwningBooleanUnsafe > createNativeBooleanInstance( final long[] dimensions, final Fraction entitiesPerPixel )
 	{
 		final long numEntities = numEntities( dimensions, entitiesPerPixel );
 
-		return new UnsafeImg<>( new OwningNativeBooleanUnsafe( numEntities ), dimensions, entitiesPerPixel );
+		return new UnsafeImg<>( new OwningBooleanUnsafe( numEntities ), dimensions, entitiesPerPixel );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeImgs.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeImgs.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeLocalizingCursor.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeLocalizingCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeLocalizingSubIntervalCursor.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeLocalizingSubIntervalCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeRandomAccess.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeRandomAccess.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/img/unsafe/UnsafeSubIntervalCursor.java
+++ b/src/main/java/net/imglib2/img/unsafe/UnsafeSubIntervalCursor.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/AbstractNativeLongAccessType.java
+++ b/src/main/java/net/imglib2/type/AbstractNativeLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/NativeLongAccessType.java
+++ b/src/main/java/net/imglib2/type/NativeLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/NativeLongAccessTypeFactory.java
+++ b/src/main/java/net/imglib2/type/NativeLongAccessTypeFactory.java
@@ -31,6 +31,7 @@ package net.imglib2.type;
 import java.util.function.Function;
 
 import net.imglib2.img.NativeLongAccessImg;
+import net.imglib2.img.basictypelongaccess.BooleanLongAccess;
 import net.imglib2.img.basictypelongaccess.ByteLongAccess;
 import net.imglib2.img.basictypelongaccess.CharLongAccess;
 import net.imglib2.img.basictypelongaccess.DoubleLongAccess;
@@ -105,6 +106,11 @@ public final class NativeLongAccessTypeFactory< T extends NativeLongAccessType< 
 	public T createLinkedType( final NativeLongAccessImg< T, ? extends A > img )
 	{
 		return createLinkedType.apply( img );
+	}
+
+	public static < T extends NativeLongAccessType< T >, A extends BooleanLongAccess > NativeLongAccessTypeFactory< T, A > BOOLEAN( final Function< NativeLongAccessImg< T, ? extends A >, T > createLinkedType )
+	{
+		return new NativeLongAccessTypeFactory<>( PrimitiveType.BOOLEAN, createLinkedType );
 	}
 
 	public static < T extends NativeLongAccessType< T >, A extends ByteLongAccess > NativeLongAccessTypeFactory< T, A > BYTE( final Function< NativeLongAccessImg< T, ? extends A >, T > createLinkedType )

--- a/src/main/java/net/imglib2/type/NativeLongAccessTypeFactory.java
+++ b/src/main/java/net/imglib2/type/NativeLongAccessTypeFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/ARGBLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/ARGBLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/ByteLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/ByteLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericByteLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericByteLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericIntLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericIntLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericLongLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericLongLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericShortLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericShortLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/IntLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/IntLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/LongLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/LongLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/ShortLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/ShortLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/real/DoubleLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/DoubleLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/net/imglib2/type/numeric/real/FloatLongAccessType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/FloatLongAccessType.java
@@ -2,7 +2,7 @@
  * #%L
  * ImgLib2 data structures using Unsafe.
  * %%
- * Copyright (C) 2017 - 2021 Howard Hughes Medical Institute.
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/net/imglib2/converter/readwrite/longaccess/LongAccessTypeToTypeConverterTest.java
+++ b/src/test/java/net/imglib2/converter/readwrite/longaccess/LongAccessTypeToTypeConverterTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.converter.readwrite.longaccess;
 
 import net.imglib2.Sampler;

--- a/src/test/java/net/imglib2/converter/readwrite/longaccess/LongAccessTypeToTypeConverterTest.java
+++ b/src/test/java/net/imglib2/converter/readwrite/longaccess/LongAccessTypeToTypeConverterTest.java
@@ -1,0 +1,211 @@
+package net.imglib2.converter.readwrite.longaccess;
+
+import net.imglib2.Sampler;
+import net.imglib2.converter.readwrite.SamplerConverter;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.complex.ComplexDoubleLongAccessType;
+import net.imglib2.type.numeric.complex.ComplexDoubleType;
+import net.imglib2.type.numeric.complex.ComplexFloatLongAccessType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
+import net.imglib2.type.numeric.integer.ByteLongAccessType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortLongAccessType;
+import net.imglib2.type.numeric.integer.IntLongAccessType;
+import net.imglib2.type.numeric.integer.LongLongAccessType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedByteLongAccessType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntLongAccessType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongLongAccessType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortLongAccessType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatLongAccessType;
+import net.imglib2.type.numeric.real.DoubleLongAccessType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.type.numeric.real.DoubleType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link SamplerConverter}s of this project
+ * 
+ * @author Gabriel Selzer
+ */
+public class LongAccessTypeToTypeConverterTest
+{
+
+	private static < T, U > U convert( T access, SamplerConverter< T, U > converter )
+	{
+		Sampler< T > sampler = new Sampler< T >()
+		{
+
+			@Override
+			public T get()
+			{
+				return access;
+			}
+
+			@Override
+			public Sampler< T > copy()
+			{
+				return null;
+			}
+		};
+		return converter.convert( sampler );
+	}
+
+	@Test
+	public void testNativeBoolean()
+	{
+		ByteLongAccessType access = new ByteLongAccessType( ( byte ) 4 );
+		NativeBoolType converted = convert( access, new ByteLongAccessTypeNativeBoolTypeConverter() );
+		boolean value = false;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( 0, access.get() );
+	}
+
+	@Test
+	public void testByte()
+	{
+		ByteLongAccessType access = new ByteLongAccessType( ( byte ) 4 );
+		ByteType converted = convert( access, new ByteLongAccessTypeByteTypeConverter() );
+		byte value = 5;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( value, access.get() );
+	}
+
+	@Test
+	public void testShort()
+	{
+		ShortLongAccessType access = new ShortLongAccessType( ( short ) 4 );
+		ShortType converted = convert( access, new ShortLongAccessTypeShortTypeConverter() );
+		short value = 5;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( value, access.get() );
+	}
+
+	@Test
+	public void testInteger()
+	{
+		IntLongAccessType access = new IntLongAccessType( 4 );
+		IntType converted = convert( access, new IntLongAccessTypeIntTypeConverter() );
+		int value = 5;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( value, access.get() );
+	}
+
+	@Test
+	public void testLong()
+	{
+		LongLongAccessType access = new LongLongAccessType( 4L );
+		LongType converted = convert( access, new LongLongAccessTypeLongTypeConverter() );
+		long value = 5L;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( value, access.get() );
+	}
+
+	@Test
+	public void testFloat()
+	{
+		FloatLongAccessType access = new FloatLongAccessType( 4f );
+		FloatType converted = convert( access, new FloatLongAccessTypeFloatTypeConverter() );
+		float value = 5f;
+		converted.set( value );
+		assertEquals( value, converted.get(), 1e-6 );
+		assertEquals( value, access.get(), 1e-6 );
+	}
+
+	@Test
+	public void testDouble()
+	{
+		DoubleLongAccessType access = new DoubleLongAccessType( 4d );
+		DoubleType converted = convert( access, new DoubleLongAccessTypeDoubleTypeConverter() );
+		double value = 5d;
+		converted.set( value );
+		assertEquals( value, converted.get(), 1e-6 );
+		assertEquals( value, access.get(), 1e-6 );
+	}
+
+	@Test
+	public void testComplexFloat()
+	{
+		ComplexFloatLongAccessType access = new ComplexFloatLongAccessType( 4f, 4f );
+		ComplexFloatType converted = convert( access, new ComplexFloatLongAccessTypeComplexFloatTypeConverter() );
+		float real = 5f;
+		float imag = 5f;
+		converted.set( real, imag );
+		assertEquals( real, converted.getRealDouble(), 1e-6 );
+		assertEquals( real, access.getRealDouble(), 1e-6 );
+		assertEquals( imag, converted.getImaginaryDouble(), 1e-6 );
+		assertEquals( imag, access.getImaginaryDouble(), 1e-6 );
+	}
+
+	@Test
+	public void testComplexDouble()
+	{
+		ComplexDoubleLongAccessType access = new ComplexDoubleLongAccessType( 4d, 4d );
+		ComplexDoubleType converted = convert( access, new ComplexDoubleLongAccessTypeComplexDoubleTypeConverter() );
+		double real = 5d;
+		double imag = 5d;
+		converted.set( real, imag );
+		assertEquals( real, converted.getRealDouble(), 1e-6 );
+		assertEquals( real, access.getRealDouble(), 1e-6 );
+		assertEquals( imag, converted.getImaginaryDouble(), 1e-6 );
+		assertEquals( imag, access.getImaginaryDouble(), 1e-6 );
+	}
+
+	@Test
+	public void testUnsignedByte()
+	{
+		UnsignedByteLongAccessType access = new UnsignedByteLongAccessType( 4 );
+		UnsignedByteType converted = convert( access, new UnsignedByteLongAccessTypeUnsignedByteTypeConverter() );
+		byte value = 5;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( value, access.get() );
+	}
+
+	@Test
+	public void testUnsignedShort()
+	{
+		UnsignedShortLongAccessType access = new UnsignedShortLongAccessType( 4 );
+		UnsignedShortType converted = convert( access, new UnsignedShortLongAccessTypeUnsignedShortTypeConverter() );
+		short value = 5;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( value, access.get() );
+	}
+
+	@Test
+	public void testUnsignedInteger()
+	{
+		UnsignedIntLongAccessType access = new UnsignedIntLongAccessType( 4 );
+		UnsignedIntType converted = convert( access, new UnsignedIntLongAccessTypeUnsignedIntTypeConverter() );
+		int value = 5;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( value, access.get() );
+	}
+
+	@Test
+	public void testUnsignedLong()
+	{
+		UnsignedLongLongAccessType access = new UnsignedLongLongAccessType( 4L );
+		UnsignedLongType converted = convert( access, new UnsignedLongLongAccessTypeUnsignedLongTypeConverter() );
+		long value = 5L;
+		converted.set( value );
+		assertEquals( value, converted.get() );
+		assertEquals( value, access.get() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/BooleanUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/BooleanUnsafeTest.java
@@ -1,0 +1,91 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imglib2.img.basictypelongaccess.unsafe.BooleanUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+
+/**
+ * Tests basic {@link BooleanUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class BooleanUnsafeTest
+{
+
+	private BooleanUnsafe b;
+
+	private long address;
+
+	private final Boolean startingValue = false;
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		b = new BooleanUnsafe( address );
+		b.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( b.getAddres() );
+	}
+
+	@Test
+	public void testBooleanUnsafeGetValue()
+	{
+		assertEquals( startingValue, b.getValue( 0 ) );
+	}
+
+	@Test
+	public void testBooleanUnsafeSetValue()
+	{
+		boolean newValue = true;
+		b.setValue( 0, newValue );
+		assertEquals( newValue, b.getValue( 0 ) );
+	}
+
+	@Test
+	public void testBooleanUnsafeGetAddress()
+	{
+		assertEquals( address, b.getAddres() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/ByteUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/ByteUnsafeTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.img.basictypeaccess.unsafe;
 
 import net.imglib2.img.basictypelongaccess.unsafe.ByteUnsafe;

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/ByteUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/ByteUnsafeTest.java
@@ -1,0 +1,62 @@
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import net.imglib2.img.basictypelongaccess.unsafe.ByteUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests basic {@link ByteUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class ByteUnsafeTest
+{
+
+	private ByteUnsafe b;
+
+	private long address;
+
+	private final Byte startingValue = 5;
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		b = new ByteUnsafe( address );
+		b.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( b.getAddres() );
+	}
+
+	@Test
+	public void testByteUnsafeGetValue()
+	{
+		assertEquals( ( long ) startingValue, b.getValue( 0 ) );
+	}
+
+	@Test
+	public void testByteUnsafeSetValue()
+	{
+		byte newValue = 6;
+		b.setValue( 0, newValue );
+		assertEquals( newValue, b.getValue( 0 ) );
+	}
+
+	@Test
+	public void testByteUnsafeGetAddress()
+	{
+		assertEquals( address, b.getAddres() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/CharUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/CharUnsafeTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.img.basictypeaccess.unsafe;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/CharUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/CharUnsafeTest.java
@@ -1,0 +1,63 @@
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imglib2.img.basictypelongaccess.unsafe.CharUnsafe;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+
+/**
+ * Tests basic {@link CharUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class CharUnsafeTest
+{
+
+	private CharUnsafe c;
+
+	private long address;
+
+	private final Character startingValue = 'a';
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		c = new CharUnsafe( address );
+		c.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( c.getAddres() );
+	}
+
+	@Test
+	public void testCharUnsafeGetValue()
+	{
+		assertEquals( ( long ) startingValue, c.getValue( 0 ) );
+	}
+
+	@Test
+	public void testCharUnsafeSetValue()
+	{
+		char newValue = 'b';
+		c.setValue( 0, newValue );
+		assertEquals( newValue, c.getValue( 0 ) );
+	}
+
+	@Test
+	public void testCharUnsafeGetAddress()
+	{
+		assertEquals( address, c.getAddres() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/DoubleUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/DoubleUnsafeTest.java
@@ -1,0 +1,63 @@
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imglib2.img.basictypelongaccess.unsafe.DoubleUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+
+/**
+ * Tests basic {@link DoubleUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class DoubleUnsafeTest
+{
+
+	private DoubleUnsafe d;
+
+	private long address;
+
+	private final Double startingValue = 5d;
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		d = new DoubleUnsafe( address );
+		d.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( d.getAddres() );
+	}
+
+	@Test
+	public void testDoubleUnsafeGetValue()
+	{
+		assertEquals( startingValue, d.getValue( 0 ), 1e-6 );
+	}
+
+	@Test
+	public void testDoubleUnsafeSetValue()
+	{
+		double newValue = 6d;
+		d.setValue( 0, newValue );
+		assertEquals( newValue, d.getValue( 0 ), 1e-6 );
+	}
+
+	@Test
+	public void testDoubleUnsafeGetAddress()
+	{
+		assertEquals( address, d.getAddres() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/DoubleUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/DoubleUnsafeTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.img.basictypeaccess.unsafe;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/FloatUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/FloatUnsafeTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.img.basictypeaccess.unsafe;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/FloatUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/FloatUnsafeTest.java
@@ -1,0 +1,63 @@
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imglib2.img.basictypelongaccess.unsafe.FloatUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+
+/**
+ * Tests basic {@link FloatUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class FloatUnsafeTest
+{
+
+	private FloatUnsafe f;
+
+	private long address;
+
+	private final Float startingValue = 5f;
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		f = new FloatUnsafe( address );
+		f.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( f.getAddres() );
+	}
+
+	@Test
+	public void testFloatUnsafeGetValue()
+	{
+		assertEquals( startingValue, f.getValue( 0 ), 1e-6 );
+	}
+
+	@Test
+	public void testFloatUnsafeSetValue()
+	{
+		float newValue = 6f;
+		f.setValue( 0, newValue );
+		assertEquals( newValue, f.getValue( 0 ), 1e-6 );
+	}
+
+	@Test
+	public void testFloatUnsafeGetAddress()
+	{
+		assertEquals( address, f.getAddres() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/IntUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/IntUnsafeTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.img.basictypeaccess.unsafe;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/IntUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/IntUnsafeTest.java
@@ -1,0 +1,63 @@
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imglib2.img.basictypelongaccess.unsafe.IntUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+
+/**
+ * Tests basic {@link IntUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class IntUnsafeTest
+{
+
+	private IntUnsafe i;
+
+	private long address;
+
+	private final Integer startingValue = 5;
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		i = new IntUnsafe( address );
+		i.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( i.getAddres() );
+	}
+
+	@Test
+	public void testIntUnsafeGetValue()
+	{
+		assertEquals( ( long ) startingValue, i.getValue( 0 ) );
+	}
+
+	@Test
+	public void testIntUnsafeSetValue()
+	{
+		int newValue = 6;
+		i.setValue( 0, newValue );
+		assertEquals( newValue, i.getValue( 0 ) );
+	}
+
+	@Test
+	public void testIntUnsafeGetAddress()
+	{
+		assertEquals( address, i.getAddres() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/LongUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/LongUnsafeTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.img.basictypeaccess.unsafe;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/LongUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/LongUnsafeTest.java
@@ -1,0 +1,63 @@
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imglib2.img.basictypelongaccess.unsafe.LongUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+
+/**
+ * Tests basic {@link LongUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class LongUnsafeTest
+{
+
+	private LongUnsafe l;
+
+	private long address;
+
+	private final Long startingValue = 5L;
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		l = new LongUnsafe( address );
+		l.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( l.getAddres() );
+	}
+
+	@Test
+	public void testLongUnsafeGetValue()
+	{
+		assertEquals( ( long ) startingValue, l.getValue( 0 ) );
+	}
+
+	@Test
+	public void testLongUnsafeSetValue()
+	{
+		long newValue = 6L;
+		l.setValue( 0, newValue );
+		assertEquals( ( long ) newValue, l.getValue( 0 ) );
+	}
+
+	@Test
+	public void testLongUnsafeGetAddress()
+	{
+		assertEquals( address, l.getAddres() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/NativeBooleanUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/NativeBooleanUnsafeTest.java
@@ -1,0 +1,63 @@
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imglib2.img.basictypelongaccess.unsafe.NativeBooleanUnsafe;
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+
+/**
+ * Tests basic {@link NativeBooleanUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class NativeBooleanUnsafeTest
+{
+
+	private NativeBooleanUnsafe b;
+
+	private long address;
+
+	private final Boolean startingValue = false;
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		b = new NativeBooleanUnsafe( address );
+		b.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( b.getAddres() );
+	}
+
+	@Test
+	public void testNativeBooleanUnsafeGetValue()
+	{
+		assertEquals( startingValue, b.getValue( 0 ) );
+	}
+
+	@Test
+	public void testNativeBooleanUnsafeSetValue()
+	{
+		boolean newValue = true;
+		b.setValue( 0, newValue );
+		assertEquals( newValue, b.getValue( 0 ) );
+	}
+
+	@Test
+	public void testNativeBooleanUnsafeGetAddress()
+	{
+		assertEquals( address, b.getAddres() );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/NativeBooleanUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/NativeBooleanUnsafeTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.img.basictypeaccess.unsafe;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/ShortUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/ShortUnsafeTest.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * ImgLib2 data structures using Unsafe.
+ * %%
+ * Copyright (C) 2017 - 2023 Howard Hughes Medical Institute.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imglib2.img.basictypeaccess.unsafe;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/net/imglib2/img/basictypeaccess/unsafe/ShortUnsafeTest.java
+++ b/src/test/java/net/imglib2/img/basictypeaccess/unsafe/ShortUnsafeTest.java
@@ -1,0 +1,63 @@
+package net.imglib2.img.basictypeaccess.unsafe;
+
+import static org.junit.Assert.assertEquals;
+
+import net.imglib2.img.basictypelongaccess.unsafe.ShortUnsafe;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.imglib2.img.basictypelongaccess.unsafe.UnsafeUtil;
+
+/**
+ * Tests basic {@link ShortUnsafe} functionality
+ * 
+ * @author Gabriel Selzer
+ */
+public class ShortUnsafeTest
+{
+
+	private ShortUnsafe s;
+
+	private long address;
+
+	private final Short startingValue = 5;
+
+	@Before
+	public void setup()
+	{
+		// Allocate heap memory for testing
+		address = UnsafeUtil.UNSAFE.allocateMemory( 8 );
+
+		s = new ShortUnsafe( address );
+		s.setValue( 0, startingValue );
+	}
+
+	@After
+	public void tearDown()
+	{
+		// Free heap memory
+		UnsafeUtil.UNSAFE.freeMemory( s.getAddres() );
+	}
+
+	@Test
+	public void testShortUnsafeGetValue()
+	{
+		assertEquals( ( long ) startingValue, s.getValue( 0 ) );
+	}
+
+	@Test
+	public void testShortUnsafeSetValue()
+	{
+		short newValue = 6;
+		s.setValue( 0, newValue );
+		assertEquals( newValue, s.getValue( 0 ) );
+	}
+
+	@Test
+	public void testShortUnsafeGetAddress()
+	{
+		assertEquals( address, s.getAddres() );
+	}
+
+}


### PR DESCRIPTION
This PR adds support for `Booleans`.

This PR is motivated by the desire to support the conversion to/from `RAI<BooleanType>` in PyImageJ.